### PR TITLE
Treat nan and inf not as numbers

### DIFF
--- a/text2digits/text2digits.py
+++ b/text2digits/text2digits.py
@@ -1,3 +1,5 @@
+import math
+
 UNITS = [
     'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight',
     'nine', 'ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen',
@@ -226,7 +228,10 @@ class Text2Digits():
         if type(x) == str:
             x = x.replace(',', '')
         try:
-            float(x)
+            x = float(x)
+
+            if math.isnan(x) or math.isinf(x):
+                return False
         except:
             return False
         return True


### PR DESCRIPTION
When the input string contained "nan" or "inf" it was previously treated as float numbers so that the number conversion did not work anymore. With this PR, these tokens are not treated as numbers anymore.