### PR TITLE
Switch to a lex-parse approach

### DIFF
--- a/tests/test_number_conversion.py
+++ b/tests/test_number_conversion.py
@@ -4,8 +4,8 @@ from text2digits import text2digits
 
 
 @pytest.mark.parametrize("input_text", [
-    ('A random string'),
-    ('Hello world. How are you?'),
+    "A random string",
+    "Hello world. How are you?",
 ])
 def test_str_unchanged_if_no_numbers(input_text):
     t2d_default = text2digits.Text2Digits()
@@ -22,8 +22,13 @@ def test_str_unchanged_if_no_numbers(input_text):
     ("hundred thousand", "100000"),
     ("one hundred thousand", "100000"),
     ("fifty five thousand", "55000"),
+    ("thousand million", "1000000000"),
+    ("two thousand hundred", "2000100"),
     ("I am twenty nine", "I am 29"),
     ("I am thirty six years old with a child that is four. I would like to get him four cars!", "I am 36 years old with a child that is 4. I would like to get him 4 cars!"),
+    ("I am the fourth cousin", "I am the 4 cousin"),
+    ("forty-two", "42"),
+    ("forty_two", "42"),
 ])
 def test_positive_integers(input_text, expected):
     t2d_default = text2digits.Text2Digits()
@@ -51,7 +56,7 @@ def test_years(input_text, expected):
 
 @pytest.mark.parametrize("input_text, expected", [
     ("it was twenty ten and was negative thirty seven degrees", "it was 2010 and was negative 37 degrees"),
-    ("I was born in nineteen ninety two and am twenty six years old!", "I was born in 1992 and am 26 years old!"),
+    ("I was born in nineteen ninety two and I am twenty six years old!", "I was born in 1992 and I am 26 years old!"),
     ("asb is twenty two altogether fifty five twelve parrot", "asb is 22 altogether 5512 parrot"),
     ("twenty eleven zero three", "201103"),
 ])
@@ -72,10 +77,13 @@ def test_multiple_types_of_numbers(input_text, expected):
     ("ninten", "ninten"),
     ("ninetin", "ninetin"),
     ("ninteen nineti niine", "ninteen nineti niine"),
-    ("forty two,  two. 0.5-1", "42,  2. 0.1"),
     ("sixty six hundred", "6600"),
     ("one two zero three", "1203"),
     ("one fifty one twenty one", "15121"),
+    ("zero twelve", "012"),
+    ("twelve zero nine", "1209"),
+    ("twenty eleven three", "20113"),
+    ("hundred and two", "102"),
 ])
 def test_others(input_text, expected):
     t2d_default = text2digits.Text2Digits()
@@ -83,58 +91,88 @@ def test_others(input_text, expected):
     assert result == expected
 
 
+@pytest.mark.parametrize("input_text,expected", [
+    ("ninteen", "19"),
+    ("nintteen", "19"),
+    ("ninten", "ninten"),
+    ("ninetin", "90"),
+    ("ninteen nineti niine", "1999"),
+])
+def test_spelling_correction(input_text, expected):
+    t2d_default = text2digits.Text2Digits(similarity_threshold=0.7)
+    result = t2d_default.convert(input_text)
+    assert result == expected
+
+
+@pytest.mark.parametrize("input_text,expected", [
+    ("forty two,  two. 0.5-1", "42,  2. 0.5-1"),
+    ("1,000 million", "1000000000"),
+    ("1,000", "1,000"),
+    ("1,000 pounds", "1,000 pounds"),
+    ("10,  20 2.0", "10,  20 2.0"),
+    ("2.5 thousand", "2500"),
+    ("1.2345 hundred", "123.45"),
+    ("twenty 1.0", "20 1.0"),
+    ("100 and two", "102"),
+])
+def test_number_literals(input_text, expected):
+    t2d_default = text2digits.Text2Digits()
+    result = t2d_default.convert(input_text)
+    assert result == expected
+
+
 @pytest.mark.parametrize("ordinal_input,convert_ordinals,add_ordinal_ending,expected", [
-    ('third', True, False, '3'),
-    ('third', False, False, 'third'),
-    ('third', True, True, '3rd'),
-    # ordinal ending 'st'
-    ('twenty-first', True, False, '21'),
-    ('twenty-first', False, False, 'twenty-first'),
-    ('twenty-first', True, True, '21st'),
-    # ordinal ending 'nd'
-    ('thirty-second', True, False, '32'),
-    ('thirty-second', False, False, 'thirty-second'),
-    ('thirty-second', True, True, '32nd'),
-    # ordinal ending 'rd'
-    ('forty-third', True, False, '43'),
-    ('forty-third', False, False, 'forty-third'),
-    ('forty-third', True, True, '43rd'),
-    # ordinal ending 'th'
-    ('tenth', True, False, '10'),
-    ('tenth', False, False, 'tenth'),
-    ('tenth', True, True, '10th'),
-    ('fifty-fourth', True, False, '54'),
-    ('fifty-fourth', False, False, 'fifty-fourth'),
-    ('fifty-fourth', True, True, '54th'),
-    # ordinal ending 'ieth'
-    ('twentieth', True, False, '20'),
-    ('twentieth', False, False, 'twentieth'),
-    ('twentieth', True, True, '20th'),
-    ('seventieth', True, False, '70'),
-    ('seventieth', False, False, 'seventieth'),
-    ('seventieth', True, True, '70th'),
+    ("third", True, False, "3"),
+    ("third", False, False, "third"),
+    ("third", True, True, "3rd"),
+    # ordinal ending "st"
+    ("twenty-first", True, False, "21"),
+    ("twenty-first", False, False, "twenty-first"),
+    ("twenty-first", True, True, "21st"),
+    # ordinal ending "nd"
+    ("thirty-second", True, False, "32"),
+    ("thirty-second", False, False, "thirty-second"),
+    ("thirty-second", True, True, "32nd"),
+    # ordinal ending "rd"
+    ("forty-third", True, False, "43"),
+    ("forty-third", False, False, "forty-third"),
+    ("forty-third", True, True, "43rd"),
+    # ordinal ending "th"
+    ("tenth", True, False, "10"),
+    ("tenth", False, False, "tenth"),
+    ("tenth", True, True, "10th"),
+    ("fifty-fourth", True, False, "54"),
+    ("fifty-fourth", False, False, "fifty-fourth"),
+    ("fifty-fourth", True, True, "54th"),
+    # ordinal ending "ieth"
+    ("twentieth", True, False, "20"),
+    ("twentieth", False, False, "twentieth"),
+    ("twentieth", True, True, "20th"),
+    ("seventieth", True, False, "70"),
+    ("seventieth", False, False, "seventieth"),
+    ("seventieth", True, True, "70th"),
     # 100, 1000, 10000, etc.
-    ('hundredth', True, False, '100'),
-    ('hundredth', False, False, 'hundredth'),
-    ('hundredth', True, True, '100th'),
-    ('seven-hundredth', True, False, '700'),
-    ('seven-hundredth', False, False, 'seven-hundredth'),
-    ('seven-hundredth', True, True, '700th'),
-    ('thousandth', True, False, '1000'),
-    ('thousandth', False, False, 'thousandth'),
-    ('thousandth', True, True, '1000th'),
-    ('ten-thousandth', True, False, '10000'),
-    ('ten-thousandth', False, False, 'ten-thousandth'),
-    ('ten-thousandth', True, True, '10000th'),
-    ('two-hundred-thousandth', True, False, '200000'),
-    ('two-hundred-thousandth', False, False, 'two-hundred-thousandth'),
-    ('two-hundred-thousandth', True, True, '200000th'),
-    ('millionth', True, False, '1000000'),
-    ('millionth', False, False, 'millionth'),
-    ('millionth', True, True, '1000000th'),
+    ("hundredth", True, False, "100"),
+    ("hundredth", False, False, "hundredth"),
+    ("hundredth", True, True, "100th"),
+    ("seven-hundredth", True, False, "700"),
+    ("seven-hundredth", False, False, "seven-hundredth"),
+    ("seven-hundredth", True, True, "700th"),
+    ("thousandth", True, False, "1000"),
+    ("thousandth", False, False, "thousandth"),
+    ("thousandth", True, True, "1000th"),
+    ("ten-thousandth", True, False, "10000"),
+    ("ten-thousandth", False, False, "ten-thousandth"),
+    ("ten-thousandth", True, True, "10000th"),
+    ("two-hundred-thousandth", True, False, "200000"),
+    ("two-hundred-thousandth", False, False, "two-hundred-thousandth"),
+    ("two-hundred-thousandth", True, True, "200000th"),
+    ("millionth", True, False, "1000000"),
+    ("millionth", False, False, "millionth"),
+    ("millionth", True, True, "1000000th"),
+    ("millionth", False, True, "1000000th"),
 ])
 def test_ordinal_conversion_switch_disabled(ordinal_input, convert_ordinals, add_ordinal_ending, expected):
-
     input_str = "she was the {} to finish the race"
     t2d_default = text2digits.Text2Digits(convert_ordinals=convert_ordinals, add_ordinal_ending=add_ordinal_ending)
     result = t2d_default.convert(input_str.format(ordinal_input))
@@ -142,12 +180,12 @@ def test_ordinal_conversion_switch_disabled(ordinal_input, convert_ordinals, add
 
 
 @pytest.mark.parametrize("ordinal_input,convert_ordinals,add_ordinal_ending,expected", [
-    ('eighth', True, False, '8'),
-    ('eighth', False, False, 'eighth'),
-    ('eighth', True, True, '8th'),
-    ('ninety-seventh', True, False, '97'),
-    ('ninety-seventh', False, False, 'ninety-seventh'),
-    ('ninety-seventh', True, True, '97th'),
+    ("eighth", True, False, "8"),
+    ("eighth", False, False, "eighth"),
+    ("eighth", True, True, "8th"),
+    ("ninety-seventh", True, False, "97"),
+    ("ninety-seventh", False, False, "ninety-seventh"),
+    ("ninety-seventh", True, True, "97th"),
 ])
 def test_ordinal_at_the_end_of_the_sentence(ordinal_input, convert_ordinals, add_ordinal_ending, expected):
     input_str = "she finished {}"
@@ -156,11 +194,10 @@ def test_ordinal_at_the_end_of_the_sentence(ordinal_input, convert_ordinals, add
     assert result == input_str.format(expected)
 
 
-def test_ordinal_multi_occurence_and_cardinal():
-    # using two ordinal numbers with different endings ('th' and 'nd')
+def test_ordinal_multi_occurrence_and_cardinal():
+    # using two ordinal numbers with different endings ("th" and "nd")
     # and a cardinal number in the middle
     input_str = "she finished sixty-fourth on race number six and he finished forty-second"
     t2d_default = text2digits.Text2Digits(convert_ordinals=True, add_ordinal_ending=True)
     result = t2d_default.convert(input_str)
     assert result == "she finished 64th on race number 6 and he finished 42nd"
-

--- a/tests/test_number_conversion.py
+++ b/tests/test_number_conversion.py
@@ -201,3 +201,18 @@ def test_ordinal_multi_occurrence_and_cardinal():
     t2d_default = text2digits.Text2Digits(convert_ordinals=True, add_ordinal_ending=True)
     result = t2d_default.convert(input_str)
     assert result == "she finished 64th on race number 6 and he finished 42nd"
+
+
+@pytest.mark.parametrize("input_text,expected_output", [
+    ('its 07', 'its 07'),
+    ('its 007', 'its 007'),
+    ('its 15:01', 'its 15:01'),
+    ('when I was eleven, I used to sleep at 23:01', 'when I was 11, I used to sleep at 23:01'),
+    ('when I was eleven, I used to sleep at 02:01', 'when I was 11, I used to sleep at 02:01'),
+    ('at 00:00 I will turn 15', 'at 00:00 I will turn 15'),
+    ('at 03:03 I will turn 15', 'at 03:03 I will turn 15'),
+])
+def test_time_formats(input_text, expected_output):
+    t2d_default = text2digits.Text2Digits()
+    result = t2d_default.convert(input_text)
+    assert result == expected_output

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,20 @@
+from text2digits import text2digits
+from text2digits.rules import CombinationRule, ConcatenationRule
+
+
+def test_parer_combination_rule():
+    cases = [('twenty one thousand three hundred', 5), ('twenty one', 2), ('hundred twenty one', 3)]
+    rule = CombinationRule()
+    t2d = text2digits.Text2Digits()
+
+    for example, number in cases:
+        assert rule.match(t2d._lex(example)) == number
+
+
+def test_parer_concatenation_rule():
+    cases = [('one ten', 2), ('three', 1), ('nineteen', 1)]
+    rule = ConcatenationRule()
+    t2d = text2digits.Text2Digits()
+
+    for example, number in cases:
+        assert rule.match(t2d._lex(example)) == number

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,0 +1,22 @@
+from text2digits import text2digits
+from text2digits.tokens_basic import WordType, Token
+
+
+def test_lexer():
+    example = 'one hundred 2.2 50 eleven forty twenty and two and bus third and'
+    types = [WordType.UNITS, WordType.SCALES, WordType.LITERAL_FLOAT, WordType.LITERAL_INT, WordType.TEENS,
+             WordType.TENS, WordType.TENS, WordType.CONJUNCTION, WordType.UNITS, WordType.OTHER, WordType.OTHER,
+             WordType.UNITS, WordType.OTHER]
+
+    t2d = text2digits.Text2Digits()
+    tokens = t2d._lex(example)
+    for token, type in zip(tokens, types):
+        assert token.type == type, token.text()
+
+    t1 = Token('100', '')
+    assert t1.has_large_scale()
+    assert t1.scale() == 100
+
+    t2 = Token('5', '')
+    assert not t2.has_large_scale()
+    assert t2.scale() == 1

--- a/text2digits/rules.py
+++ b/text2digits/rules.py
@@ -1,0 +1,174 @@
+import enum
+from abc import ABC, abstractmethod
+from decimal import Decimal
+from typing import List, Union
+
+from text2digits.tokens_basic import WordType, Token, NoneToken
+from text2digits.tokens_rules import CombinedToken, ConcatenatedToken, RuleToken
+
+
+class Rule(ABC):
+    """
+    Rules are used to parse a sequence of tokens and to apply a rule on the detected tokens to retrieve a new number representation.
+    """
+
+    @abstractmethod
+    def match(self, tokens: List[Union[Token, RuleToken]]) -> int:
+        """
+        Analyses the tokens and tries to find a consecutive sequence of tokens which should be combined for the specified rule. The focus of this function lies on *which* tokens should be combined (instead of *how*).
+
+        :param tokens: List of tokens.
+        :return: Number of tokens which match the specified rule.
+        """
+        pass
+
+    @abstractmethod
+    def action(self, tokens: List[Union[Token, RuleToken]]) -> RuleToken:
+        """
+        Combines the tokens and replaces it with a new token (e.g. converted number). The focus of this function lies on *how* tokens should be combined (instead of *which*).
+
+        :param tokens: The tokens to be combined.
+        :return: The new token which replaces the input tokens.
+        """
+        pass
+
+
+class CombinationRule(Rule):
+    """
+    This rule handles all the (complicated) cases where we actually need to calculate the output number (e.g. two hundred forty-two --> 2*100 + 40 + 2 = 242).
+    """
+
+    def __init__(self):
+        self.valid_types = [WordType.LITERAL_INT, WordType.LITERAL_FLOAT, WordType.UNITS, WordType.TEENS, WordType.TENS, WordType.SCALES]
+
+    def match(self, tokens: List[Token]) -> int:
+        class MatchType(enum.Enum):
+            SINGLE = 0
+            SCALE = 1
+            DUAl_SCALE = 2
+            DUAL_HUNDRED = 3
+
+        # We need at least two tokens to combine something
+        if len(tokens) < 2:
+            return 0
+
+        last_match = None
+        last_scale = 0
+        consumed_tokens = 0
+        while consumed_tokens < len(tokens):
+            consumed_conjunctions = 0
+            first = tokens[consumed_tokens]
+
+            # In case of a conjunction, we are interested in the word which follows next
+            if consumed_tokens > 0 and first.type == WordType.CONJUNCTION:
+                # Consume the conjunction
+                consumed_conjunctions = 1
+                first = tokens[consumed_tokens + consumed_conjunctions]
+
+            # Same for the second considered token. However, it is a bit more complicated in this case since we may reach the end of the string
+            second = tokens[consumed_tokens + consumed_conjunctions + 1] if consumed_tokens < len(tokens) - consumed_conjunctions - 1 else NoneToken()
+            if second.type == WordType.CONJUNCTION:
+                consumed_conjunctions = 1
+                second = tokens[consumed_tokens + consumed_conjunctions + 1] if consumed_tokens < len(tokens) - consumed_conjunctions - 1 else NoneToken()
+
+            # Now the tricky part: we need to decide how many tokens we need to combine
+            if last_match != MatchType.DUAL_HUNDRED and first.type == WordType.TENS and second.type == WordType.UNITS:
+                # e.g. twenty one -> consume both
+                consumed_tokens += 2
+                last_match = MatchType.DUAL_HUNDRED
+            elif first.type in self.valid_types and second.has_large_scale():
+                # e.g. 2.1 hundred -> consume both (result 210)
+                consumed_tokens += 2
+                last_match = MatchType.DUAl_SCALE
+                last_scale = second.scale()
+            elif first.has_large_scale() and (second.type in self.valid_types or last_match == MatchType.DUAL_HUNDRED):
+                # e.g. *hundred two -> consume hundred
+                # e.g. twenty one *hundred -> twenty one already consumed by the first condition
+
+                # It is important to just consume the scale to handle cases like hundred twenty one
+                consumed_tokens += 1
+                last_match = MatchType.SCALE
+                last_scale = first.scale()
+            elif last_match in [MatchType.SCALE, MatchType.DUAl_SCALE] and first.has_large_scale():
+                # Two consecutive scales are only allowed when the scale increases
+                # e.g. hundred thousand -> ok
+                # e.g. thousand hundred -> no valid number
+                if first.scale() > last_scale:
+                    consumed_tokens += 1
+                    last_match = MatchType.SCALE
+                else:
+                    last_match = None
+            elif last_match in [MatchType.SCALE, MatchType.DUAl_SCALE] and first.type in self.valid_types:
+                # e.g. hundred *two -> consume two
+                consumed_tokens += 1
+                last_match = MatchType.SINGLE
+            else:
+                last_match = None
+
+            if last_match is None:
+                break
+
+            consumed_tokens += consumed_conjunctions
+
+        return consumed_tokens
+
+    def action(self, tokens: List[Token]) -> CombinedToken:
+        assert len(tokens) >= 2, 'At least two tokens are required'
+
+        current = Decimal(0)
+        result = Decimal(0)
+        last_glue = ''
+        prev_scale = 1
+
+        for token in tokens:
+            assert token.type != WordType.OTHER, 'Invalid token type (only numbers are allowed here)'
+
+            if token.has_large_scale():
+                # Multiply the scale at least with a value of 1 (and not 0)
+                current = max(1, current)
+
+            if token.scale() < prev_scale:
+                # Flush the result when switching from a larger to a smaller scale
+                # e.g. one thousand *FLUSH* six hundred *FLUSH* sixty six
+                result += current
+                current = Decimal(0)
+
+            current = current * token.scale() + token.value()
+            last_glue = token.glue
+            prev_scale = token.scale()
+
+        result += current
+
+        return CombinedToken(tokens, result, last_glue)
+
+
+class ConcatenationRule(Rule):
+    """
+    This rule handles all the "year cases" like twenty twenty where we simply concatenate the numbers together. The numbers are already transformed to digits by the CombinationRule.
+    """
+    def __init__(self):
+        self.valid_types = [WordType.UNITS, WordType.TEENS, WordType.TENS, WordType.SCALES, WordType.REPLACED]
+
+    def match(self, tokens: List[Union[Token, CombinedToken]]) -> int:
+        i = 0
+
+        # Find all numeric tokens
+        while i < len(tokens):
+            if tokens[i].type in self.valid_types:
+                i += 1
+            else:
+                break
+
+        return i
+
+    def action(self, tokens: List[Union[Token, CombinedToken]]) -> ConcatenatedToken:
+        assert len(tokens) >= 1, 'At least one token is required'
+
+        last_glue = ''
+        result = ''
+
+        for token in tokens:
+            result += token.text()
+            last_glue = token.glue
+
+        return ConcatenatedToken(tokens, result, last_glue)

--- a/text2digits/text2digits.py
+++ b/text2digits/text2digits.py
@@ -1,275 +1,134 @@
-import re
-import math
+from typing import List
 
-UNITS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine']
-TEENS = ['ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen', 'eighteen', 'nineteen']
-TENS = ['ten', 'twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy', 'eighty', 'ninety', 'hundred', 'thousand', 'million', 'billion']
-SCALES = ['hundred', 'thousand', 'million', 'billion', 'trillion']
-ORDINAL_WORDS = {'oh': 0, 'first': 1, 'second': 2, 'third': 3, 'fourth': 4, 'fifth': 5, 'sixth': 6, 'seventh': 7, 'eighth': 8, 'ninth': 9, 'twelfth': 12}
-ORDINAL_ENDINGS = [('ieth', 'y'), ('th', '')]
+from text2digits.tokens_basic import Token, WordType
+from text2digits.rules import CombinationRule, ConcatenationRule
+from text2digits.text_processing_helpers import split_glues, find_similar_word
 
 
-class TextPreprocessor:
-    @staticmethod
-    def bigram(word1, word2):
-        '''
-        Returns the bigram similarity of 2 words
-        '''
-        word1 = word1.lower()
-        word2 = word2.lower()
-        word1_length = len(word1)
-        word2_length = len(word2)
-        pairs1 = []
-        pairs2 = []
+class Text2Digits(object):
+    def __init__(self, similarity_threshold=1.0, convert_ordinals=True, add_ordinal_ending=False):
+        """
+        This class can be used to convert text representations of numbers to digits. That is, it replaces all occurrences of numbers (e.g. forty-two) to the digit representation (e.g. 42).
 
-        for i in range(word1_length):
-            if i == word1_length - 1:
-                continue
-            pairs1.append(word1[i] + word1[i + 1])
+        Basic usage:
 
-        for i in range(word2_length):
-            if i == word2_length - 1:
-                continue
-            pairs2.append(word2[i] + word2[i + 1])
+        >>> from text2digits import text2digits
+        >>> t2d = text2digits.Text2Digits()
+        >>> t2d.convert("twenty ten and twenty one")
+        >>> 2010 and 21
 
-        similar = [word for word in pairs1 if word in pairs2]
+        :param similarity_threshold: Used for spelling correction. It specifies the minimal similarity in the range [0, 1] of a word to one of the number words. 0 inidcates that every other word is similar and 1 requires a perfect match, i.e. no spelling correction is performed with a value of 1.
+        :param convert_ordinals: Whether to convert ordinal numbers (e.g. third --> 3).
+        :param add_ordinal_ending: Whether to add the ordinal ending to the converted ordinal number (e.g. twentieth --> 20th). Implies convert_ordinals=True.
+        """
+        self.similarity_threshold = similarity_threshold
 
-        return float(len(similar)) / float(max(len(pairs1), len(pairs2)))
+        if self.similarity_threshold < 0 or self.similarity_threshold > 1:
+            raise ValueError('The similarity_threshold must be in the range [0, 1]')
 
-    @staticmethod
-    def get_similarity(item1, item2):
-        '''
-        Returns a number within the range (0,1) determining how similar
-        item1 is to item2. 0 indicates perfect dissimilarity while 1
-        indicates equality.
-        '''
-        return TextPreprocessor.bigram(item1, item2)
-    
-    @staticmethod
-    def get_match(word, collection, threshold):
-        '''
-        Returns the most syntactically similar word in the collection
-        to the specified word.
-        '''
-        match = None
-        max_similarity = 0
-        
-        for item in collection:
-            similarity = TextPreprocessor.get_similarity(word, item)
-            if similarity > max(max_similarity, threshold):
-                match = item
-                max_similarity = similarity
-                
-        return match
-
-    @staticmethod
-    def split_glues(string, separator=r'\s+'):
-        '''
-        Splits a string and preserves the glue, i.e. the separator fragments.
-        This is useful when words of a sentence should be processed while still
-        keeping the possibility to recover the original sentence.
-
-        :param string: The string to be split.
-        :param separator: The separator to use for splitting (defaults to
-        whitespace).
-        :return: A generator yielding (match, glue) pairs, e.g. the word and
-                 the whitespace next to it. If no glue is left, an empty string
-                 is returned.
-        '''
-        while True:
-            match = re.search(separator, string)
-            if not match:
-                # The last word does not have a glue
-                yield string, ''
-                break
-
-            yield string[:match.start()], match.group()
-
-            # Proceed with the remaining string
-            string = string[match.end():]
-
-
-class Text2Digits():
-    def __init__(self, excluded_chars="", similarity_threshold=0.5, convert_ordinals=True, add_ordinal_ending=False):
-        self.excluded = excluded_chars
-        self.accepted = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -"
-        self.numwords = dict()
-        self.threshold = similarity_threshold
         self.convert_ordinals = convert_ordinals
         self.add_ordinal_ending = add_ordinal_ending
 
-        self.numwords['and'] = (1, 0)
-        for idx, word in enumerate(UNITS): self.numwords[word] = (1, idx)
-        for idx, word in enumerate(TEENS): self.numwords[word] = (1, idx + 10)
-        for idx, word in enumerate(TENS): self.numwords[word] = (1, (idx + 1) * 10)
-        for idx, word in enumerate(SCALES): self.numwords[word] = (10 ** (idx * 3 or 2), 0)
+        # Keeping the ordinal ending implies that we convert ordinal numbers
+        if self.add_ordinal_ending:
+            self.convert_ordinals = True
 
-    def convert(self, phrase, spell_check=False):
-        substr_arr, punctuation_arr = self.get_substr_punctuation(phrase)
-        digits_arr = []
+    def convert(self, text: str) -> str:
+        """
+        Converts all number representations to digits.
 
-        for substr in substr_arr:
-            digits_arr.append(self.convert_to_digits(substr, spell_check))
+        :param text: The input string.
+        :return: The input string with all numbers replaced with their corresponding digit representation.
+        """
 
-        # Recreate the phrase by zipping the converted phrases with the punctuations
-        digits_phrase = "".join([sstr + punct for sstr, punct in zip(digits_arr, punctuation_arr)])
+        # Tokenize the input string by assigning a type to each word (e.g. representing the number type like units (e.g. one) or teens (twelve))
+        # This makes it easier for the subsequent steps to decide which parts of the sentence need to be combined
+        # e.g. I like forty-two apples --> I [WordType.Other] like [WordType.Other] forty [WordType.TENS] two [WordType.UNITS] apples [WordType.Other]
+        tokens = self._lex(text)
 
-        return digits_phrase
+        # Apply a set of rules to the tokens to combine the numeric tokens and replace them with the corresponding digit
+        # e.g. I [WordType.Other] like [WordType.Other] 42 [ConcatenatedToken] apples [WordType.Other] (it merged the TENS and UNITS tokens)
+        text = self._parse(tokens)
 
-    """
-    This function takes in a phrase and outputs an array of substring split by punctuation and an array of
-    all the punctuations that were stripped out
-    """
+        return text
 
-    def get_substr_punctuation(self, phrase):
-        substr_arr = []
-        punctuation_arr = []
-        substr = ""
-        strlen = len(phrase)
-        count = 0
+    def _lex(self, text: str) -> List[Token]:
+        """
+        This function takes an arbitrary input string, splits it into tokens (words) and assigns each token a type corresponding to the role in the sentence.
 
-        for char in phrase:
-            count += 1
-            if char in (self.accepted + self.excluded):
-                substr += char
-            else:
-                substr_arr.append(substr)
-                punctuation_arr.append(char)
-                substr = ""
+        :param text: The input string.
+        :return: The tokenized input string.
+        """
+        tokens = []
 
-            # when there is no punctuation in a sentence
-            if count == strlen and substr:
-                substr_arr.append(substr)
-                punctuation_arr.append("")
+        conjunctions = []
+        for i, (word, glue) in enumerate(split_glues(text)):
+            # Address spelling corrections
+            if self.similarity_threshold != 1:
+                matched_num = find_similar_word(word, Token.numwords.keys(), self.similarity_threshold)
+                if matched_num is not None:
+                    word = matched_num
 
-        return substr_arr, punctuation_arr
+            token = Token(word, glue)
+            tokens.append(token)
 
-    """
-    Modified version of answers from: 
-    https://stackoverflow.com/questions/493174/is-there-a-way-to-convert-number-words-to-integers
-    """
+            # Conjunctions need special treatment since they can be used for both, to combine numbers or to combine other parts in the sentence
+            if token.type == WordType.CONJUNCTION:
+                conjunctions.append(i)
 
-    def convert_to_digits(self, textnum, spell_check=False):
-        if self.convert_ordinals:
-            # split ordinals to calculate the number. Example: 'twenty-first'
-            textnum = textnum.replace('-', ' ')
-        current = result = word_count = 0
-        curstring = ''
-        onnumber = lastunit = lastscale = is_tens = False
-        last_number_glue = ''
-        ordinal_ending = ''
+        # A word should only have the type WordType.CONJUNCTION when it actually combines two digits and not some other words in the sentence
+        for i in conjunctions:
+            if i >= len(tokens) - 1 or tokens[i + 1].type in [WordType.CONJUNCTION, WordType.OTHER]:
+                tokens[i].type = WordType.OTHER
 
-        for word, glue in TextPreprocessor.split_glues(textnum):
-            word_count += 1
-            word_original = word
-            word = word.lower()
-            if self.convert_ordinals and word in ORDINAL_WORDS:
-                scale, increment = (1, ORDINAL_WORDS[word])
-                current = current * scale + increment
-                if scale > 100:
-                    result += current
-                    current = 0
-                onnumber = True
-                last_number_glue = glue
-                lastunit = lastscale = is_tens = False
-                if self.add_ordinal_ending:
-                    ordinal_ending = word[-2:]
+        return tokens
 
-            else:
-                # Handle endings
-                if self.convert_ordinals:
-                    for ending, replacement in ORDINAL_ENDINGS:
-                        if word.endswith(ending):
-                            word_modified = "%s%s" % (word[:-len(ending)], replacement)
-                            if word_modified in UNITS or word_modified in TENS:
-                                if self.add_ordinal_ending:
-                                    ordinal_ending = word[-2:]
-                                word = word_modified
+    def _parse(self, tokens: List[Token]) -> str:
+        """
+        Parses the tokenized input based on predefined rules which combine certain tokens to find the correct digit representation of the textual number description.
 
-                # Handle misspelt words
-                if spell_check:
-                    matched_num = TextPreprocessor.get_match(word, self.numwords.keys(), self.threshold)
-                    if matched_num is not None:
-                        word = matched_num
-                
-                # Is not a number word
-                if (not self.is_numword(word)) or (word == 'and' and not lastscale):
-                    if onnumber:
-                        # Flush the current number we are building
-                        curstring += repr(result + current) + ordinal_ending + last_number_glue
-                        ordinal_ending = ''
-                    curstring += word_original + glue
+        :param tokens: The tokenized input string.
+        :return: The transformed input string.
+        """
+        rules = [CombinationRule(), ConcatenationRule()]
 
-                    result = current = 0
-                    onnumber = False
-                    lastunit = False
-                    lastscale = False
-                    is_tens = False
+        # Apply each rule to process the tokens
+        for rule in rules:
+            new_tokens = []
+            i = 0
 
-                # Is a number word
+            while i < len(tokens):
+                if tokens[i].is_ordinal() and not self.convert_ordinals:
+                    # When keeping ordinal numbers, treat the whole number (which may consists of multiple parts, e.g. ninety-seventh) as a normal word
+                    tokens[i].type = WordType.OTHER
+
+                if tokens[i].type != WordType.OTHER:
+                    # Check how many tokens this rule wants to process...
+                    n_match = rule.match(tokens[i:])
+                    if n_match > 0:
+                        # ... and then merge these tokens into a new one (e.g. a token representing the digit)
+                        token = rule.action(tokens[i:i + n_match])
+                        new_tokens.append(token)
+                        i += n_match
+                    else:
+                        new_tokens.append(tokens[i])
+                        i += 1
                 else:
-                    scale, increment = self.from_numword(word)
-                    onnumber = True
-                    last_number_glue = glue
+                    new_tokens.append(tokens[i])
+                    i += 1
 
-                    # For cases such as twenty ten -> 2010, twenty nineteen -> 2019
-                    if is_tens and word not in (UNITS + SCALES):
-                        curstring += repr(result + current)
-                        result = current = 0
+            tokens = new_tokens
 
-                    if lastunit and (word not in SCALES):
-                        # Assume this is part of a string of individual numbers to
-                        # be flushed, such as a zipcode "one two three four five"
-                        curstring += repr(result + current)
-                        result = current = 0
+        # Combine the tokens back to a string (with special handling of ordinal numbers)
+        text = ''
+        for token in tokens:
+            if token.is_ordinal() and not self.convert_ordinals:
+                text += token.word_raw
+            else:
+                text += token.text()
+                if token.is_ordinal() and self.add_ordinal_ending:
+                    text += token.ordinal_ending
 
-                    if scale > 1:
-                        current = max(1, current)
+            text += token.glue
 
-                    current = current * scale + increment
-                    if scale > 100:
-                        result += current
-                        current = 0
-
-                    lastscale = False
-                    lastunit = False
-                    is_tens = False
-                    if word in SCALES:
-                        lastscale = True
-                    elif word in (UNITS + TEENS):
-                        lastunit = True
-                    elif word in TENS:
-                        is_tens = True
-
-        # Flush remaining number (in case the last word of a sentence corresponds to a number)
-        if onnumber:
-            curstring += repr(result + current) + ordinal_ending + last_number_glue
-
-        return curstring
-
-    def is_numword(self, x):
-        if self.is_number(x):
-            return True
-        if x in self.numwords:
-            return True
-        return False
-
-    def from_numword(self, x):
-        if self.is_number(x):
-            scale = 0
-            increment = int(x.replace(',', ''))
-            return scale, increment
-        return self.numwords[x]
-
-    def is_number(self, x):
-        if type(x) == str:
-            x = x.replace(',', '')
-        try:
-            x = float(x)
-
-            if math.isnan(x) or math.isinf(x):
-                return False
-        except:
-            return False
-        return True
-
+        return text

--- a/text2digits/text_processing_helpers.py
+++ b/text2digits/text_processing_helpers.py
@@ -1,0 +1,77 @@
+import re
+from typing import Iterator, List
+
+
+def bigram_similarity(word1: str, word2: str) -> float:
+    """
+    Returns a number within the range [0, 1] determining how similar
+    item1 is to item2. 0 indicates perfect dissimilarity while 1
+    indicates equality. The similarity value is calculated by counting
+    the number of bigrams both words share in common.
+    """
+    word1 = word1.lower()
+    word2 = word2.lower()
+    word1_length = len(word1)
+    word2_length = len(word2)
+    pairs1 = []
+    pairs2 = []
+
+    for i in range(word1_length):
+        if i == word1_length - 1:
+            continue
+        pairs1.append(word1[i] + word1[i + 1])
+
+    for i in range(word2_length):
+        if i == word2_length - 1:
+            continue
+        pairs2.append(word2[i] + word2[i + 1])
+
+    similar = [word for word in pairs1 if word in pairs2]
+
+    return float(len(similar)) / float(max(len(pairs1), len(pairs2)))
+
+
+def find_similar_word(word: str, collection: List, threshold: float) -> str:
+    """
+    Returns the most syntactically similar word in the collection
+    to the specified word.
+    """
+    match = None
+    max_similarity = 0
+
+    for item in collection:
+        similarity = bigram_similarity(word, item)
+
+        # The similarity must be above the threshold and if this is true for
+        # multiple words, we take the most similar one
+        if similarity > max(max_similarity, threshold):
+            match = item
+            max_similarity = similarity
+
+    return match
+
+
+def split_glues(text: str, separator=r'\s+|(?<=\D)[.,;:\-_](?=\D)') -> Iterator[str]:
+    """
+    Splits a string and preserves the glue, i.e. the separator fragments.
+    This is useful when words of a sentence should be processed while still
+    keeping the possibility to recover the original sentence.
+
+    :param text: The string to be split.
+    :param separator: The separator to use for splitting (defaults to
+    whitespace).
+    :return: A generator yielding (match, glue) pairs, e.g. the word and
+             the whitespace next to it. If no glue is left, an empty string
+             is returned.
+    """
+    while True:
+        match = re.search(separator, text)
+        if not match:
+            # The last word does not have a glue
+            yield text, ''
+            break
+
+        yield text[:match.start()], match.group()
+
+        # Proceed with the remaining string
+        text = text[match.end():]

--- a/text2digits/tokens_basic.py
+++ b/text2digits/tokens_basic.py
@@ -1,0 +1,152 @@
+import enum
+import re
+from decimal import Decimal
+
+
+class WordType(enum.Enum):
+    OTHER = 0
+    LITERAL_INT = 1
+    LITERAL_FLOAT = 2
+    UNITS = 3
+    TEENS = 4
+    TENS = 5
+    SCALES = 6
+    CONJUNCTION = 7
+    REPLACED = 8
+
+
+class Token(object):
+    # Static init code (only executed once and not for each token instance)
+    UNITS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine']
+    TEENS = ['ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen', 'eighteen',
+             'nineteen']
+    TENS = ['twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy', 'eighty', 'ninety']
+    SCALES = ['hundred', 'thousand', 'million', 'billion', 'trillion']
+    CONJUNCTION = ['and']
+    ORDINAL_WORDS = {'oh': 'zero', 'first': 'one', 'second': 'two', 'third': 'three', 'fifth': 'five',
+                     'eighth': 'eight', 'ninth': 'nine', 'twelfth': 'twelve'}
+    ORDINAL_ENDINGS = [('ieth', 'y'), ('th', '')]
+
+    numwords = {
+        'and': (1, 0)  # (scale, value)
+    }
+    for idx, word in enumerate(UNITS):
+        numwords[word] = (1, idx)
+    for idx, word in enumerate(TEENS):
+        numwords[word] = (1, idx + 10)
+    for idx, word in enumerate(TENS):
+        numwords[word] = (1, (idx + 2) * 10)
+    for idx, word in enumerate(SCALES):
+        numwords[word] = (10 ** (idx * 3 or 2), 0)
+
+    def __init__(self, word: str, glue: str):
+        """
+        Represents a word in the text with some additional knowledge about the word (e.g. information about its type).
+
+        :param word: The string representation in the text.
+        :param glue: The glue (e.g. whitespace) which follows the word.
+        """
+        self.word_raw = word
+        self.glue = glue
+
+        # Basic preprocessing of the word to find the type
+        self._word = word.lower().replace(',', '')
+
+        # Try to match ordinal numbers and then treat them as cardinal ones
+        self.ordinal_ending = None  # We need to keep a reference to the original ending in case the user wants to preserve it
+        if self._word in Token.ORDINAL_WORDS:
+            self.ordinal_ending = self._word[-2:]
+            self._word = Token.ORDINAL_WORDS[self._word]
+
+        for ending, replacement in Token.ORDINAL_ENDINGS:
+            if self._word.endswith(ending):
+                replaced = self._word[:-len(ending)] + replacement
+                if replaced in Token.numwords:
+                    self.ordinal_ending = self._word[-2:]
+                    self._word = replaced
+
+        # Assign a type to each token (from specific to general)
+        if self._word in Token.UNITS:
+            self.type = WordType.UNITS
+        elif self._word in Token.TEENS:
+            self.type = WordType.TEENS
+        elif self._word in Token.TENS:
+            self.type = WordType.TENS
+        elif self._word in Token.SCALES:
+            self.type = WordType.SCALES
+        elif self._word in Token.CONJUNCTION:
+            self.type = WordType.CONJUNCTION
+        elif re.search(r'\d+\.\d*|\d*\.\d+', self._word):
+            self.type = WordType.LITERAL_FLOAT
+        elif re.search(r'\d+', self._word):
+            self.type = WordType.LITERAL_INT
+        else:
+            self.type = WordType.OTHER
+
+    def __repr__(self) -> str:
+        return f'{self._word} ({self.type})'
+
+    def is_ordinal(self) -> bool:
+        return self.ordinal_ending is not None
+
+    def has_large_scale(self) -> bool:
+        """
+        Returns True when the token has a scale >= 100.
+        """
+        if self.type == WordType.SCALES:
+            return True
+        elif self.type in [WordType.LITERAL_INT, WordType.LITERAL_FLOAT]:
+            return Decimal(self._word) >= 100 and Decimal(self._word) % 10 == 0
+        else:
+            return False
+
+    def value(self) -> Decimal:
+        """
+        Returns the value of a token (e.g. twelve -> 12). SCALES have a value of 0 since they are defined by their scale and not by their value, e.g. for two hundred we calculate 2 * 100 + 0.
+        """
+        if self.type in [WordType.LITERAL_INT, WordType.LITERAL_FLOAT]:
+            if self.has_large_scale():
+                return Decimal(0)
+            else:
+                return Decimal(self._word)
+        elif self.type != WordType.OTHER:
+            return Decimal(Token.numwords[self._word][1])
+
+    def scale(self) -> Decimal:
+        """
+        Returns the scale of a token (e.g. hundred -> 100).
+        """
+        if self.type in [WordType.LITERAL_INT, WordType.LITERAL_FLOAT]:
+            if self.has_large_scale():
+                return Decimal(self._word)
+            else:
+                return Decimal(1)
+        elif self.type != WordType.OTHER:
+            return Decimal(Token.numwords[self._word][0])
+
+    def text(self) -> str:
+        """
+        Returns the textual (digit) representation of the token (e.g. twelve -> 12).
+        """
+        if self.type in [WordType.LITERAL_INT, WordType.LITERAL_FLOAT, WordType.CONJUNCTION, WordType.OTHER]:
+            # Keep the original representation of the literal in case there were e.g. some thousand separators
+            return self.word_raw
+        elif self.type == WordType.SCALES:
+            return str(self.scale())
+        else:
+            return str(self.value())
+
+
+class NoneToken(object):
+    """
+    Special token type which serves as a mock-up for a word which does not exist in the input.
+    """
+
+    def __init__(self):
+        self.type = None
+
+    def is_ordinal(self) -> bool:
+        return False
+
+    def has_large_scale(self) -> bool:
+        return False

--- a/text2digits/tokens_basic.py
+++ b/text2digits/tokens_basic.py
@@ -76,9 +76,9 @@ class Token(object):
             self.type = WordType.SCALES
         elif self._word in Token.CONJUNCTION:
             self.type = WordType.CONJUNCTION
-        elif re.search(r'\d+\.\d*|\d*\.\d+', self._word):
+        elif re.search(r'^\d+\.\d*|\d*\.\d+$', self._word):
             self.type = WordType.LITERAL_FLOAT
-        elif re.search(r'\d+', self._word):
+        elif re.search(r'^\d+$', self._word):
             self.type = WordType.LITERAL_INT
         else:
             self.type = WordType.OTHER

--- a/text2digits/tokens_rules.py
+++ b/text2digits/tokens_rules.py
@@ -1,0 +1,81 @@
+from abc import ABC, abstractmethod
+from decimal import Decimal
+from typing import List
+
+from text2digits.tokens_basic import WordType, Token
+
+
+class RuleToken(ABC):
+    def __init__(self, original_tokens: List[Token]):
+        """
+        Base class for tokens which are used during rule processing.
+
+        :param original_tokens: List of tokens which are combined by the rule.
+        """
+        super().__init__()
+        self.original_tokens = original_tokens
+
+        # The last token determines the ordinal ending, e.g. thirty-second --> nd
+        self.ordinal_ending = self.original_tokens[-1].ordinal_ending
+
+        # Build a representation of the original word consisting of all tokens
+        self.word_raw = ''
+        for i, token in enumerate(self.original_tokens):
+            self.word_raw += token.word_raw
+            if i < len(self.original_tokens) - 1:
+                # The rule token is responsible for keeping the glue between the individual tokens (e.g. the hyphens in "two-hundred-thousandth") but not the glue of the last token
+                self.word_raw += token.glue
+
+    def is_ordinal(self) -> bool:
+        return any([token.is_ordinal() for token in self.original_tokens])
+
+    @abstractmethod
+    def text(self) -> str:
+        pass
+
+
+class CombinedToken(RuleToken):
+    """
+    Special token type which is used by the CombinationRule.
+    """
+
+    def __init__(self, original_tokens: List[Token], value: Decimal, glue: str):
+        super().__init__(original_tokens)
+        self._value = value
+        self.glue = glue
+        self.type = WordType.REPLACED
+
+    def __repr__(self) -> str:
+        return str(self._value)
+
+    def value(self) -> Decimal:
+        return self._value
+
+    def scale(self) -> Decimal:
+        return Decimal(1)
+
+    def text(self) -> str:
+        number = self.value()
+
+        # Remove tailing zeros, e.g. 1.2345 hundred -> 123.4500 -> 123.45
+        number = number.to_integral() if number == number.to_integral() else number.normalize()
+
+        return str(number)
+
+
+class ConcatenatedToken(RuleToken):
+    """
+    Special token type which is used by the ConcatenationRule.
+    """
+
+    def __init__(self, original_tokens: List[Token], text: str, glue: str):
+        super().__init__(original_tokens)
+        self._text = text
+        self.glue = glue
+        self.type = WordType.REPLACED
+
+    def __repr__(self) -> str:
+        return str(self._text)
+
+    def text(self) -> str:
+        return self._text


### PR DESCRIPTION
This is a major rewrite of the library with a switch to a "lex and parse" approach. The idea is to simplify the implementation by introducing a multi-step process (inspired by how compiler work):

1. Lexer: the first step is to assign each word in the input sequence a token. A token knows something about the word like its type or its value. The focus is only on an individual word and not on its surrounding or how it should be combined.
2. Parser: the second step takes care of the combination of tokens to calculate the value of a digit. This is based on some predefined rules. Each rule first checks how many tokens it wants to consume and then applies an action on these tokens to create a new token. Currently, there are only two rules: a combination rule to handle cases like `forty-two` where we need to calculate something and a second concatenation rule which handles cases like `twenty twenty`, i.e. years where we only need to concatenate numbers.

I also took the chance and split the implementation into several files.

This is, however, not just a rewrite but also introduces new functionality/fixes some bugs. For a start, the issues #25 and #26 are fixed automatically, i.e. without further adjustments. I also added several new test cases, some of them did not work before (see attached test log). A general new feature is the support of literals in the input string to handle cases like `2.5 thousand -> 2500`.

The goal was to ease the implementation process by reducing complexity making it easier to fix bugs or add new features. I hope you like it :-)

[Test Results - pytest_in_tests.zip](https://github.com/ShailChoksi/text2digits/files/4541809/Test.Results.-.pytest_in_tests.zip)

