### PR TITLE
Feature/date fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="text2digits",
-    version="0.0.9",
+    version="0.1.0",
     author="Shail Choksi",
     author_email="choksishail@gmail.com",
     description="A small library to convert text numbers to digits in a string",

--- a/tests/test_number_conversion.py
+++ b/tests/test_number_conversion.py
@@ -217,3 +217,24 @@ def test_time_formats(input_text, expected_output):
     t2d_default = text2digits.Text2Digits()
     result = t2d_default.convert(input_text)
     assert result == expected_output
+
+
+@pytest.mark.parametrize("input_text,expected_output", [
+    ('it is january or jan for short', 'it is 1 or 1 for short'),
+    ('it is february or feb for short', 'it is 2 or 2 for short'),
+    ('it is march or mar for short', 'it is 3 or 3 for short'),
+    ('it is april or apr for short', 'it is 4 or 4 for short'),
+    ('it is may or may for short', 'it is 5 or 5 for short'),
+    ('it is june or jun for short', 'it is 6 or 6 for short'),
+    ('it is july or jul for short', 'it is 7 or 7 for short'),
+    ('it is august or aug for short', 'it is 8 or 8 for short'),
+    ('it is september or sep for short', 'it is 9 or 9 for short'),
+    ('it is october or oct for short', 'it is 10 or 10 for short'),
+    ('it is november or nov for short', 'it is 11 or 11 for short'),
+    ('it is december or dec for short', 'it is 12 or 12 for short'),
+    ('i was born on july four, 1776', 'i was born on 7 4, 1776'),
+])
+def test_month_formats(input_text, expected_output):
+    t2d_default = text2digits.Text2Digits()
+    result = t2d_default.convert(input_text)
+    assert result == expected_output

--- a/tests/test_number_conversion.py
+++ b/tests/test_number_conversion.py
@@ -217,24 +217,3 @@ def test_time_formats(input_text, expected_output):
     t2d_default = text2digits.Text2Digits()
     result = t2d_default.convert(input_text)
     assert result == expected_output
-
-
-@pytest.mark.parametrize("input_text,expected_output", [
-    ('it is january or jan for short', 'it is 1 or 1 for short'),
-    ('it is february or feb for short', 'it is 2 or 2 for short'),
-    ('it is march or mar for short', 'it is 3 or 3 for short'),
-    ('it is april or apr for short', 'it is 4 or 4 for short'),
-    ('it is may or may for short', 'it is 5 or 5 for short'),
-    ('it is june or jun for short', 'it is 6 or 6 for short'),
-    ('it is july or jul for short', 'it is 7 or 7 for short'),
-    ('it is august or aug for short', 'it is 8 or 8 for short'),
-    ('it is september or sep for short', 'it is 9 or 9 for short'),
-    ('it is october or oct for short', 'it is 10 or 10 for short'),
-    ('it is november or nov for short', 'it is 11 or 11 for short'),
-    ('it is december or dec for short', 'it is 12 or 12 for short'),
-    ('i was born on july four, 1776', 'i was born on 7 4, 1776'),
-])
-def test_month_formats(input_text, expected_output):
-    t2d_default = text2digits.Text2Digits()
-    result = t2d_default.convert(input_text)
-    assert result == expected_output

--- a/tests/test_number_conversion.py
+++ b/tests/test_number_conversion.py
@@ -114,6 +114,7 @@ def test_spelling_correction(input_text, expected):
     ("1.2345 hundred", "123.45"),
     ("twenty 1.0", "20 1.0"),
     ("100 and two", "102"),
+    ('6 2020', '6 2020'),
 ])
 def test_number_literals(input_text, expected):
     t2d_default = text2digits.Text2Digits()

--- a/text2digits/tokens_basic.py
+++ b/text2digits/tokens_basic.py
@@ -22,6 +22,7 @@ class Token(object):
              'nineteen']
     TENS = ['twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy', 'eighty', 'ninety']
     SCALES = ['hundred', 'thousand', 'million', 'billion', 'trillion']
+    SCALE_VALUES = [100, 1000, 1000000, 1000000000, 1000000000000] # used for has_large_scale
     CONJUNCTION = ['and']
     ORDINAL_WORDS = {'oh': 'zero', 'first': 'one', 'second': 'two', 'third': 'three', 'fifth': 'five',
                      'eighth': 'eight', 'ninth': 'nine', 'twelfth': 'twelve'}
@@ -96,7 +97,8 @@ class Token(object):
         if self.type == WordType.SCALES:
             return True
         elif self.type in [WordType.LITERAL_INT, WordType.LITERAL_FLOAT]:
-            return Decimal(self._word) >= 100 and Decimal(self._word) % 10 == 0
+            # whether the value is a scale (e.g. 100, 1000, 1000000, etc.)
+            return Decimal(self._word) in self.SCALE_VALUES
         else:
             return False
 

--- a/text2digits/tokens_basic.py
+++ b/text2digits/tokens_basic.py
@@ -13,7 +13,6 @@ class WordType(enum.Enum):
     SCALES = 6
     CONJUNCTION = 7
     REPLACED = 8
-    MONTH = 9
 
 
 class Token(object):
@@ -28,8 +27,6 @@ class Token(object):
     ORDINAL_WORDS = {'oh': 'zero', 'first': 'one', 'second': 'two', 'third': 'three', 'fifth': 'five',
                      'eighth': 'eight', 'ninth': 'nine', 'twelfth': 'twelve'}
     ORDINAL_ENDINGS = [('ieth', 'y'), ('th', '')]
-    MONTHS = ['january', 'february', 'march', 'april', 'may', 'june', 'july', 'august', 'september', 'october', 'november', 'december']
-    MMM_MONTHS = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
 
     numwords = {
         'and': (1, 0)  # (scale, value)
@@ -42,10 +39,6 @@ class Token(object):
         numwords[word] = (1, (idx + 2) * 10)
     for idx, word in enumerate(SCALES):
         numwords[word] = (10 ** (idx * 3 or 2), 0)
-    for idx, word in enumerate(MONTHS):
-        numwords[word] = (1, idx + 1)
-    for idx, word in enumerate(MMM_MONTHS):
-        numwords[word] = (1, idx + 1)
 
     def __init__(self, word: str, glue: str):
         """
@@ -88,8 +81,6 @@ class Token(object):
             self.type = WordType.LITERAL_FLOAT
         elif re.search(r'^\d+$', self._word):
             self.type = WordType.LITERAL_INT
-        elif self._word in Token.MONTHS or self._word in Token.MMM_MONTHS:
-            self.type = WordType.MONTH
         else:
             self.type = WordType.OTHER
 

--- a/text2digits/tokens_basic.py
+++ b/text2digits/tokens_basic.py
@@ -13,6 +13,7 @@ class WordType(enum.Enum):
     SCALES = 6
     CONJUNCTION = 7
     REPLACED = 8
+    MONTH = 9
 
 
 class Token(object):
@@ -27,6 +28,8 @@ class Token(object):
     ORDINAL_WORDS = {'oh': 'zero', 'first': 'one', 'second': 'two', 'third': 'three', 'fifth': 'five',
                      'eighth': 'eight', 'ninth': 'nine', 'twelfth': 'twelve'}
     ORDINAL_ENDINGS = [('ieth', 'y'), ('th', '')]
+    MONTHS = ['january', 'february', 'march', 'april', 'may', 'june', 'july', 'august', 'september', 'october', 'november', 'december']
+    MMM_MONTHS = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
 
     numwords = {
         'and': (1, 0)  # (scale, value)
@@ -39,6 +42,10 @@ class Token(object):
         numwords[word] = (1, (idx + 2) * 10)
     for idx, word in enumerate(SCALES):
         numwords[word] = (10 ** (idx * 3 or 2), 0)
+    for idx, word in enumerate(MONTHS):
+        numwords[word] = (1, idx + 1)
+    for idx, word in enumerate(MMM_MONTHS):
+        numwords[word] = (1, idx + 1)
 
     def __init__(self, word: str, glue: str):
         """
@@ -81,6 +88,8 @@ class Token(object):
             self.type = WordType.LITERAL_FLOAT
         elif re.search(r'^\d+$', self._word):
             self.type = WordType.LITERAL_INT
+        elif self._word in Token.MONTHS or self._word in Token.MMM_MONTHS:
+            self.type = WordType.MONTH
         else:
             self.type = WordType.OTHER
 


### PR DESCRIPTION
fixes #31 

Modified the logic for `Token.has_large_scale` so that `WordType.LITERAL_INT` and `WordType.LITERAL_FLOAT` only return True if their values are equal to one of the listed `SCALES`

It also wasn't clear from the issue whether the month not being represented as a number was considered a problem so I created a new `WordType.MONTH` for months and the conventional 3 character abbreviation (e.g. november and nov) that returns the integer value for a given month.