### PR TITLE
Fix trailing sentence punctuation breaking number conversion (closes #50)

### DIFF
--- a/tests/test_number_conversion.py
+++ b/tests/test_number_conversion.py
@@ -147,6 +147,24 @@ def test_decimal_inputs_do_not_crash(input_text, expected):
     assert result == expected
 
 
+@pytest.mark.parametrize("input_text,expected", [
+    # End-of-sentence punctuation should not stop a trailing number from converting
+    ("I am twenty nine.", "I am 29."),
+    ("She was born in nineteen twenty.", "She was born in 1920."),
+    ("I was born in nineteen ninety two.", "I was born in 1992."),
+    ("He is thirty six.", "He is 36."),
+    ("Really; thirty six", "Really; 36"),
+    # Multi-sentence inputs still work
+    ("I am thirty. She is forty.", "I am 30. She is 40."),
+    # Trailing punctuation-only token (e.g., ellipsis in source text)
+    ("thirty six...", "36..."),
+])
+def test_trailing_sentence_punctuation(input_text, expected):
+    t2d_default = text2digits.Text2Digits()
+    result = t2d_default.convert(input_text)
+    assert result == expected
+
+
 @pytest.mark.parametrize("ordinal_input,convert_ordinals,add_ordinal_ending,expected", [
     ("third", True, False, "3"),
     ("third", False, False, "third"),

--- a/text2digits/text_processing_helpers.py
+++ b/text2digits/text_processing_helpers.py
@@ -51,7 +51,7 @@ def find_similar_word(word: str, collection: List, threshold: float) -> str:
     return match
 
 
-def split_glues(text: str, separator=r'\s+|(?<=\D)[.,;:\-_](?=\D)') -> Iterator[str]:
+def split_glues(text: str, separator=r'\s+|(?<=\D)[.,;:\-_](?=\D|$)') -> Iterator[str]:
     """
     Splits a string and preserves the glue, i.e. the separator fragments.
     This is useful when words of a sentence should be processed while still


### PR DESCRIPTION
Follow-up to #51. A commit for this fix was pushed to that PR's branch just as the merge button was clicked, so it didn't land in master — filing separately.

## Problem

End-of-sentence punctuation (`.`, `,`, `;`) between a number word and end-of-string was not recognized as a separator, so any number at the end of a sentence got mangled:

```
>>> t2d.convert("I am twenty nine.")
'I am 20 nine.'
>>> t2d.convert("She was born in nineteen twenty.")
'She was born in 19 twenty.'
>>> t2d.convert("I was born in nineteen ninety two.")
'I was born in 1990 two.'
```

The separator pattern was `r'\s+|(?<=\D)[.,;:\-_](?=\D)'`. The trailing `(?=\D)` required a literal non-digit *after* the punctuation. At end-of-string the lookahead failed, so `twenty.` stayed as a single opaque token and broke downstream concatenation.

## Fix

Extend the lookahead to `(?=\D|$)` so end-of-string counts as a non-digit boundary.

```
>>> t2d.convert("I am twenty nine.")
'I am 29.'
>>> t2d.convert("She was born in nineteen twenty.")
'She was born in 1920.'
>>> t2d.convert("I was born in nineteen ninety two.")
'I was born in 1992.'
```

Three-character regex change, no other code touched.

## Test plan

- [x] Added `test_trailing_sentence_punctuation` (7 cases): trailing `.`, `;`, multi-sentence inputs, trailing ellipsis.
- [x] Full suite: 143 passed (was 136 after #51).
- [x] Verified the original reproductions from issue #50.

Closes #50.