### PR TITLE
Fix off-by-one error in find_similar_word

### DIFF
--- a/tests/test_text_processing_helpers.py
+++ b/tests/test_text_processing_helpers.py
@@ -1,5 +1,5 @@
 import pytest
-from text2digits.text_processing_helpers import bigram_similarity
+from text2digits.text_processing_helpers import bigram_similarity, find_similar_word
 
 
 class TestBigramSimilarity:
@@ -34,3 +34,36 @@ class TestBigramSimilarity:
 
     def test_one_empty_one_nonempty(self):
         assert bigram_similarity("", "a") == 0.0
+
+
+class TestFindSimilarWord:
+    def test_exact_threshold_is_accepted(self):
+        """A candidate whose similarity equals the threshold must be returned."""
+        # "night" vs "night" → similarity 1.0; threshold 1.0 should still match.
+        assert find_similar_word("night", ["night"], threshold=1.0) == "night"
+
+    def test_below_threshold_is_rejected(self):
+        """A candidate whose similarity is strictly below the threshold returns None."""
+        # "abc" vs "xyz" → similarity 0.0; any positive threshold rejects it.
+        assert find_similar_word("abc", ["xyz"], threshold=0.1) is None
+
+    def test_most_similar_wins_above_threshold(self):
+        """When multiple candidates meet the threshold, the most similar one wins."""
+        result = find_similar_word("night", ["nightly", "night", "days"], threshold=0.5)
+        assert result == "night"
+
+    def test_no_candidates_returns_none(self):
+        assert find_similar_word("hello", [], threshold=0.5) is None
+
+    def test_threshold_zero_accepts_any_positive_similarity(self):
+        """threshold=0 accepts a word as long as it has any bigram overlap."""
+        # "abc" vs "abz" share the bigram "ab", so similarity > 0
+        result = find_similar_word("abc", ["abz"], threshold=0.0)
+        assert result == "abz"
+
+    def test_zero_similarity_never_returned(self):
+        """A candidate with 0.0 similarity is never returned, even at threshold=0."""
+        # "abc" vs "xyz" share no bigrams → similarity == 0.0, ties with
+        # the initial max_similarity of 0, so the strict > check keeps it out.
+        result = find_similar_word("abc", ["xyz"], threshold=0.0)
+        assert result is None

--- a/text2digits/text_processing_helpers.py
+++ b/text2digits/text_processing_helpers.py
@@ -45,9 +45,9 @@ def find_similar_word(word: str, collection: List, threshold: float) -> str:
     for item in collection:
         similarity = bigram_similarity(word, item)
 
-        # The similarity must be above the threshold and if this is true for
-        # multiple words, we take the most similar one
-        if similarity > max(max_similarity, threshold):
+        # The similarity must meet or exceed the threshold and if this is true
+        # for multiple words, we take the most similar one
+        if similarity >= threshold and similarity > max_similarity:
             match = item
             max_similarity = similarity
 


### PR DESCRIPTION
### `find_similar_word` threshold boundary is off-by-one
**File:** [`text_processing_helpers.py:47`](g:\Development\text2digits\text2digits\text_processing_helpers.py)

```python
if similarity > max(max_similarity, threshold):  # strict >
```

The docstring says "minimal similarity", implying ≥ threshold should be accepted. A word with similarity exactly equal to `threshold` is silently rejected. This means `threshold=0.5` won't match a word with exactly 0.5 similarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes matching semantics in `find_similar_word` by accepting candidates at the exact threshold, which may alter downstream word selection in edge cases; scope is small and covered by new tests.
> 
> **Overview**
> Fixes an off-by-one threshold check in `find_similar_word` so candidates with `similarity == threshold` are considered matches while still selecting the highest-similarity candidate.
> 
> Adds targeted unit tests for `find_similar_word` covering threshold boundary behavior, empty candidate lists, and ensuring zero-similarity candidates are never returned (even when `threshold=0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15e16fbeca736e85f9e47226fe16a10c2b1ff0e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->