### PR TITLE
Raise valueError if value/scale didnt match

### DIFF
--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,3 +1,4 @@
+import pytest
 from text2digits import text2digits
 from text2digits.tokens_basic import WordType, Token
 
@@ -20,3 +21,38 @@ def test_lexer():
     t2 = Token('5', '')
     assert not t2.has_large_scale()
     assert t2.scale() == 1
+
+
+class TestOtherTokenValueScale:
+    """value() and scale() must raise ValueError for OTHER tokens, not silently return None."""
+
+    def _other_token(self) -> Token:
+        t = Token('bus', '')
+        assert t.type == WordType.OTHER
+        return t
+
+    def test_value_raises_for_other(self):
+        with pytest.raises(ValueError, match="Cannot compute value"):
+            self._other_token().value()
+
+    def test_scale_raises_for_other(self):
+        with pytest.raises(ValueError, match="Cannot compute scale"):
+            self._other_token().scale()
+
+    def test_error_message_includes_word(self):
+        t = Token('foobar', '')
+        with pytest.raises(ValueError, match="foobar"):
+            t.value()
+
+    def test_value_valid_for_numword_types(self):
+        """Sanity-check that non-OTHER tokens still return a Decimal, not None."""
+        from decimal import Decimal
+        assert Token('twelve', '').value() == Decimal(12)
+        assert Token('hundred', '').value() == Decimal(0)
+        assert Token('42', '').value() == Decimal(42)
+
+    def test_scale_valid_for_numword_types(self):
+        from decimal import Decimal
+        assert Token('twelve', '').scale() == Decimal(1)
+        assert Token('hundred', '').scale() == Decimal(100)
+        assert Token('100', '').scale() == Decimal(100)

--- a/text2digits/tokens_basic.py
+++ b/text2digits/tokens_basic.py
@@ -115,6 +115,7 @@ class Token(object):
                 return Decimal(self._word)
         elif self.type != WordType.OTHER:
             return Decimal(Token.numwords[self._word][1])
+        raise ValueError(f"Cannot compute value for token of type {self.type!r} (word={self.word_raw!r})")
 
     def scale(self) -> Decimal:
         """
@@ -127,6 +128,7 @@ class Token(object):
                 return Decimal(1)
         elif self.type != WordType.OTHER:
             return Decimal(Token.numwords[self._word][0])
+        raise ValueError(f"Cannot compute scale for token of type {self.type!r} (word={self.word_raw!r})")
 
     def text(self) -> str:
         """


### PR DESCRIPTION
### `value()` and `scale()` implicitly return `None` for `OTHER` tokens
**File:** [`tokens_basic.py:107–129`](g:\Development\text2digits\text2digits\tokens_basic.py)

```python
def value(self) -> Decimal:
    if self.type in [WordType.LITERAL_INT, WordType.LITERAL_FLOAT]:
        ...
    elif self.type != WordType.OTHER:
        return Decimal(Token.numwords[self._word][1])
    # implicit None return for OTHER — contradicts return type hint
```

Calling `.value()` or `.scale()` on an `OTHER` token returns `None`, but the return type is `Decimal`. The `action()` method in `CombinationRule` asserts against this but asserts can be disabled with `-O`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `Token.value()`/`Token.scale()` behavior for `WordType.OTHER` from implicit `None` to raising `ValueError`, which may break callers that previously tolerated `None` (especially when asserts are disabled). Tests reduce regression risk but this is still an API/behavior change.
> 
> **Overview**
> `Token.value()` and `Token.scale()` now **raise `ValueError` for `WordType.OTHER` tokens** instead of implicitly returning `None`, with error messages that include the token type and original word.
> 
> Adds pytest coverage to assert the new exception behavior for non-numeric tokens and to sanity-check that numeric token types still return `Decimal` values/scales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56b6b8b86436961d6cae3704b5e1660e1274925f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->