### PR TITLE
Bugfix for  enum is re-created on every

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,5 +1,5 @@
 from text2digits import text2digits
-from text2digits.rules import CombinationRule, ConcatenationRule
+from text2digits.rules import CombinationRule, ConcatenationRule, MatchType
 
 
 def test_parer_combination_rule():
@@ -18,3 +18,29 @@ def test_parer_concatenation_rule():
 
     for example, number in cases:
         assert rule.match(t2d._lex(example)) == number
+
+
+class TestMatchType:
+    def test_match_type_is_module_level(self):
+        """MatchType must be importable at module level, not recreated per call."""
+        import text2digits.rules as rules_module
+        assert hasattr(rules_module, 'MatchType'), "MatchType should be a module-level name"
+
+    def test_match_type_members(self):
+        assert MatchType.SINGLE.value == 0
+        assert MatchType.SCALE.value == 1
+        assert MatchType.DUAL_SCALE.value == 2
+        assert MatchType.DUAL_HUNDRED.value == 3
+
+    def test_dual_scale_typo_is_gone(self):
+        """The old typo DUAl_SCALE must no longer exist."""
+        assert not hasattr(MatchType, 'DUAl_SCALE')
+
+    def test_match_type_identity_stable_across_calls(self):
+        """The same MatchType class is used across repeated match() calls."""
+        rule = CombinationRule()
+        t2d = text2digits.Text2Digits()
+        tokens = t2d._lex('two hundred')
+        # Call match() twice and verify we get consistent token counts,
+        # which indirectly proves the shared enum is not broken by re-creation.
+        assert rule.match(tokens) == rule.match(tokens)

--- a/text2digits/rules.py
+++ b/text2digits/rules.py
@@ -33,6 +33,13 @@ class Rule(ABC):
         pass
 
 
+class MatchType(enum.Enum):
+    SINGLE = 0
+    SCALE = 1
+    DUAL_SCALE = 2
+    DUAL_HUNDRED = 3
+
+
 class CombinationRule(Rule):
     """
     This rule handles all the (complicated) cases where we actually need to calculate the output number (e.g. two hundred forty-two --> 2*100 + 40 + 2 = 242).
@@ -42,12 +49,6 @@ class CombinationRule(Rule):
         self.valid_types = [WordType.LITERAL_INT, WordType.LITERAL_FLOAT, WordType.UNITS, WordType.TEENS, WordType.TENS, WordType.SCALES]
 
     def match(self, tokens: List[Token]) -> int:
-        class MatchType(enum.Enum):
-            SINGLE = 0
-            SCALE = 1
-            DUAl_SCALE = 2
-            DUAL_HUNDRED = 3
-
         # We need at least two tokens to combine something
         if len(tokens) < 2:
             return 0
@@ -79,7 +80,7 @@ class CombinationRule(Rule):
             elif first.type in self.valid_types and second.has_large_scale():
                 # e.g. 2.1 hundred -> consume both (result 210)
                 consumed_tokens += 2
-                last_match = MatchType.DUAl_SCALE
+                last_match = MatchType.DUAL_SCALE
                 last_scale = second.scale()
             elif first.has_large_scale() and (second.type in self.valid_types or last_match == MatchType.DUAL_HUNDRED):
                 # e.g. *hundred two -> consume hundred
@@ -89,7 +90,7 @@ class CombinationRule(Rule):
                 consumed_tokens += 1
                 last_match = MatchType.SCALE
                 last_scale = first.scale()
-            elif last_match in [MatchType.SCALE, MatchType.DUAl_SCALE] and first.has_large_scale():
+            elif last_match in [MatchType.SCALE, MatchType.DUAL_SCALE] and first.has_large_scale():
                 # Two consecutive scales are only allowed when the scale increases
                 # e.g. hundred thousand -> ok
                 # e.g. thousand hundred -> no valid number
@@ -98,7 +99,7 @@ class CombinationRule(Rule):
                     last_match = MatchType.SCALE
                 else:
                     last_match = None
-            elif last_match in [MatchType.SCALE, MatchType.DUAl_SCALE] and first.type in self.valid_types:
+            elif last_match in [MatchType.SCALE, MatchType.DUAL_SCALE] and first.type in self.valid_types:
                 # e.g. hundred *two -> consume two
                 consumed_tokens += 1
                 last_match = MatchType.SINGLE


### PR DESCRIPTION
### `MatchType` enum is re-created on every `match()` call
**File:** [`rules.py:45–49`](g:\Development\text2digits\text2digits\rules.py)

```python
def match(self, tokens):
    class MatchType(enum.Enum):
        SINGLE = 0
        SCALE = 1
        DUAl_SCALE = 2   # ← typo: DUAl vs DUAL
        DUAL_HUNDRED = 3
```

A new class object is created on every single `match()` invocation. This is inefficient for large texts and also contains a naming typo (`DUAl_SCALE`).