### PR TITLE
Fix how 'oh' is handled

### DIFF
--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,4 +1,5 @@
 import pytest
+from decimal import Decimal
 from text2digits import text2digits
 from text2digits.tokens_basic import WordType, Token
 
@@ -52,7 +53,36 @@ class TestOtherTokenValueScale:
         assert Token('42', '').value() == Decimal(42)
 
     def test_scale_valid_for_numword_types(self):
-        from decimal import Decimal
         assert Token('twelve', '').scale() == Decimal(1)
         assert Token('hundred', '').scale() == Decimal(100)
         assert Token('100', '').scale() == Decimal(100)
+
+
+class TestOhToken:
+    """'oh' is a spoken alias for zero (phone numbers) and must NOT be an ordinal."""
+
+    def test_oh_type_is_units(self):
+        assert Token('oh', '').type == WordType.UNITS
+
+    def test_oh_is_not_ordinal(self):
+        assert Token('oh', '').is_ordinal() is False
+
+    def test_oh_value_is_zero(self):
+        assert Token('oh', '').value() == Decimal(0)
+
+    def test_oh_scale_is_one(self):
+        assert Token('oh', '').scale() == Decimal(1)
+
+    def test_oh_does_not_collide_with_units_index(self):
+        """'oh' must have value 0, not 10 (what appending to UNITS list would give)."""
+        assert Token('oh', '').value() == Decimal(0)
+        assert 'oh' not in Token.UNITS
+
+    def test_phone_number_concatenation(self):
+        """'four oh seven' should produce '407', not '4 0 7'."""
+        t2d = text2digits.Text2Digits()
+        assert t2d.convert('four oh seven') == '407'
+
+    def test_oh_case_insensitive(self):
+        assert Token('Oh', '').type == WordType.UNITS
+        assert Token('OH', '').type == WordType.UNITS

--- a/text2digits/tokens_basic.py
+++ b/text2digits/tokens_basic.py
@@ -25,7 +25,7 @@ class Token(object):
     SCALE_VALUES = [100, 1_000, 10_000, 1_000_000, 10_000_000, 1_000_000_000, 100_000_000_000, 1_000_000_000_000]  # used for has_large_scale
     INDIAN_SCALES = ['lakh', 'crore', 'arab', 'kharab']
     CONJUNCTION = ['and']
-    ORDINAL_WORDS = {'oh': 'zero', 'first': 'one', 'second': 'two', 'third': 'three', 'fifth': 'five',
+    ORDINAL_WORDS = {'first': 'one', 'second': 'two', 'third': 'three', 'fifth': 'five',
                      'eighth': 'eight', 'ninth': 'nine', 'twelfth': 'twelve'}
     ORDINAL_ENDINGS = [('ieth', 'y'), ('th', '')]
 
@@ -42,6 +42,7 @@ class Token(object):
         numwords[word] = (10 ** (idx * 3 or 2), 0)
     for idx, word in enumerate(INDIAN_SCALES):
         numwords[word] = (10 ** (5 + idx * 2), 0)
+    numwords['oh'] = (1, 0)  # alias for zero; kept separate to avoid index-10 collision in UNITS enumeration
 
     def __init__(self, word: str, glue: str):
         """
@@ -70,7 +71,9 @@ class Token(object):
                     self._word = replaced
 
         # Assign a type to each token (from specific to general)
-        if self._word in Token.UNITS:
+        if self._word == 'oh':
+            self.type = WordType.UNITS
+        elif self._word in Token.UNITS:
             self.type = WordType.UNITS
         elif self._word in Token.TEENS:
             self.type = WordType.TEENS


### PR DESCRIPTION
### `"oh"` is incorrectly classified as an ordinal number
**File:** [`tokens_basic.py:61–63`](g:\Development\text2digits\text2digits\tokens_basic.py)

```python
ORDINAL_WORDS = {'oh': 'zero', 'first': 'one', ...}
```

`"oh"` is an alternate pronunciation of zero (e.g. phone numbers: "four oh seven") and is not an ordinal. Its presence in `ORDINAL_WORDS` causes `is_ordinal()` to return `True` for it, which breaks `ConcatenationRule` (ordinals are excluded from concatenation). So "four oh seven" produces "4 0 7" instead of "407".