### PR TITLE
Add break statement to stop double processing

### DIFF
--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -86,3 +86,37 @@ class TestOhToken:
     def test_oh_case_insensitive(self):
         assert Token('Oh', '').type == WordType.UNITS
         assert Token('OH', '').type == WordType.UNITS
+
+
+class TestOrdinalEndingBreak:
+    """A word matching the first ordinal-ending rule must not be re-processed by the second."""
+
+    def test_twentieth_resolves_to_twenty(self):
+        # 'twentieth' matches ('ieth', 'y') → 'twenty'; the loop must stop there.
+        # Without the break the loop would continue and try ('th', '') on 'twenty',
+        # find 'twen' which is not in numwords, but mutate _word to 'twen' first.
+        t = Token('twentieth', '')
+        assert t._word == 'twenty'
+        assert t.is_ordinal()
+
+    def test_thirtieth_resolves_to_thirty(self):
+        t = Token('thirtieth', '')
+        assert t._word == 'thirty'
+        assert t.is_ordinal()
+
+    def test_fortieth_resolves_to_forty(self):
+        t = Token('fortieth', '')
+        assert t._word == 'forty'
+        assert t.is_ordinal()
+
+    def test_ieth_match_does_not_fall_through_to_th(self):
+        """After an 'ieth' match the token type must be TENS, not OTHER."""
+        t = Token('twentieth', '')
+        assert t.type == WordType.TENS
+
+    def test_plain_th_ordinal_still_works(self):
+        """Words that only match the 'th' rule are unaffected by the break."""
+        t = Token('sixth', '')
+        assert t._word == 'six'
+        assert t.is_ordinal()
+        assert t.type == WordType.UNITS

--- a/text2digits/tokens_basic.py
+++ b/text2digits/tokens_basic.py
@@ -69,6 +69,7 @@ class Token(object):
                 if replaced in Token.numwords:
                     self.ordinal_ending = self._word[-2:]
                     self._word = replaced
+                    break
 
         # Assign a type to each token (from specific to general)
         if self._word == 'oh':


### PR DESCRIPTION

### Missing `break` in ordinal-ending loop allows double-processing
**File:** [`tokens_basic.py:65–70`](g:\Development\text2digits\text2digits\tokens_basic.py)

```python
for ending, replacement in Token.ORDINAL_ENDINGS:
    if self._word.endswith(ending):
        replaced = self._word[:-len(ending)] + replacement
        if replaced in Token.numwords:
            self.ordinal_ending = self._word[-2:]
            self._word = replaced
            # no break!
```

For a word matching the first rule (e.g. `'ieth'`), `_word` is updated to the base form. The loop continues and may then try to match `'th'` against the updated `_word`. In current data this doesn't corrupt output, but it is fragile and could mismatch if the vocabulary expands.