### PR TITLE
Replace assert with explicit `if len(tokens) < 2: raise ValueError(...)`

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,3 +1,4 @@
+import pytest
 from text2digits import text2digits
 from text2digits.rules import CombinationRule, ConcatenationRule, MatchType
 from text2digits.tokens_basic import Token, WordType
@@ -45,6 +46,38 @@ class TestMatchType:
         # Call match() twice and verify we get consistent token counts,
         # which indirectly proves the shared enum is not broken by re-creation.
         assert rule.match(tokens) == rule.match(tokens)
+
+
+class TestActionPreconditions:
+    """action() must raise ValueError for invalid input, not silently pass under -O."""
+
+    def test_combination_action_raises_for_empty_list(self):
+        with pytest.raises(ValueError, match="CombinationRule"):
+            CombinationRule().action([])
+
+    def test_combination_action_raises_for_single_token(self):
+        with pytest.raises(ValueError, match="CombinationRule"):
+            CombinationRule().action([Token('two', '')])
+
+    def test_combination_action_error_includes_count(self):
+        with pytest.raises(ValueError, match="1"):
+            CombinationRule().action([Token('two', '')])
+
+    def test_concatenation_action_raises_for_empty_list(self):
+        with pytest.raises(ValueError, match="ConcatenationRule"):
+            ConcatenationRule().action([])
+
+    def test_concatenation_action_accepts_single_token(self):
+        """ConcatenationRule requires >= 1 token; a single token must succeed."""
+        token = Token('two', '')
+        result = ConcatenationRule().action([token])
+        assert result is not None
+
+    def test_combination_action_succeeds_with_two_tokens(self):
+        """Sanity-check that valid input still works after the assert→ValueError change."""
+        tokens = [Token('two', ' '), Token('hundred', '')]
+        result = CombinationRule().action(tokens)
+        assert result is not None
 
 
 class TestConjunctionHandling:

--- a/text2digits/rules.py
+++ b/text2digits/rules.py
@@ -114,7 +114,8 @@ class CombinationRule(Rule):
         return consumed_tokens
 
     def action(self, tokens: List[Token]) -> CombinedToken:
-        assert len(tokens) >= 2, 'At least two tokens are required'
+        if len(tokens) < 2:
+            raise ValueError(f"CombinationRule.action requires at least 2 tokens, got {len(tokens)}")
 
         current = Decimal(0)
         result = Decimal(0)
@@ -164,7 +165,8 @@ class ConcatenationRule(Rule):
         return i
 
     def action(self, tokens: List[Union[Token, CombinedToken]]) -> ConcatenatedToken:
-        assert len(tokens) >= 1, 'At least one token is required'
+        if len(tokens) < 1:
+            raise ValueError(f"ConcatenationRule.action requires at least 1 token, got {len(tokens)}")
 
         last_glue = ''
         result = ''


### PR DESCRIPTION
### `assert` used for user-facing validation in `action()` methods
**File:** [`rules.py:116, 166`](g:\Development\text2digits\text2digits\rules.py)

```python
assert len(tokens) >= 2, 'At least two tokens are required'
```

`assert` statements are stripped when Python is run with `-O`. Internal invariant checks are fine with asserts, but preconditions visible at module boundaries should raise `ValueError` or `TypeError`.