### PR TITLE
Fix type hints

### DIFF
--- a/text2digits/text_processing_helpers.py
+++ b/text2digits/text_processing_helpers.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterator, List
+from typing import Iterable, Iterator, Optional, Tuple
 
 
 def bigram_similarity(word1: str, word2: str) -> float:
@@ -34,7 +34,7 @@ def bigram_similarity(word1: str, word2: str) -> float:
     return float(len(similar)) / float(denominator)
 
 
-def find_similar_word(word: str, collection: List, threshold: float) -> str:
+def find_similar_word(word: str, collection: Iterable[str], threshold: float) -> Optional[str]:
     """
     Returns the most syntactically similar word in the collection
     to the specified word.
@@ -54,7 +54,7 @@ def find_similar_word(word: str, collection: List, threshold: float) -> str:
     return match
 
 
-def split_glues(text: str, separator=r'\s+|(?<=\D)[.,;:\-_](?=\D|$)') -> Iterator[str]:
+def split_glues(text: str, separator: str = r'\s+|(?<=\D)[.,;:\-_](?=\D|$)') -> Iterator[Tuple[str, str]]:
     """
     Splits a string and preserves the glue, i.e. the separator fragments.
     This is useful when words of a sentence should be processed while still

--- a/text2digits/tokens_basic.py
+++ b/text2digits/tokens_basic.py
@@ -1,6 +1,7 @@
 import enum
 import re
 from decimal import Decimal
+from typing import Optional
 
 
 class WordType(enum.Enum):
@@ -44,7 +45,7 @@ class Token(object):
         numwords[word] = (10 ** (5 + idx * 2), 0)
     numwords['oh'] = (1, 0)  # alias for zero; kept separate to avoid index-10 collision in UNITS enumeration
 
-    def __init__(self, word: str, glue: str):
+    def __init__(self, word: str, glue: str) -> None:
         """
         Represents a word in the text with some additional knowledge about the word (e.g. information about its type).
 
@@ -152,8 +153,8 @@ class NoneToken(object):
     Special token type which serves as a mock-up for a word which does not exist in the input.
     """
 
-    def __init__(self):
-        self.type = None
+    def __init__(self) -> None:
+        self.type: Optional[WordType] = None
 
     def is_ordinal(self) -> bool:
         return False


### PR DESCRIPTION
### Incomplete / incorrect type hints
**Files:** [`text_processing_helpers.py:34`](g:\Development\text2digits\text2digits\text_processing_helpers.py), [`tokens_basic.py:107–129`](g:\Development\text2digits\text2digits\tokens_basic.py)

- `collection: List` — missing generic parameter, should be `Iterable[str]`
- `value() -> Decimal` and `scale() -> Decimal` are lies: both can return `None` (see Bug 1.3)
- `find_similar_word(…) -> str` is a lie: it initialises `match = None` and returns it unchanged when no word exceeds the threshold, so the real return type is `Optional[str]`
- Several methods lack return type annotations
