### PR TITLE
Assign self._rules in __init__

### DIFF
--- a/text2digits/text2digits.py
+++ b/text2digits/text2digits.py
@@ -33,6 +33,8 @@ class Text2Digits(object):
         if self.add_ordinal_ending:
             self.convert_ordinals = True
 
+        self._rules = [CombinationRule(), ConcatenationRule()]
+
     def convert(self, text: str) -> str:
         """
         Converts all number representations to digits.
@@ -90,10 +92,8 @@ class Text2Digits(object):
         :param tokens: The tokenized input string.
         :return: The transformed input string.
         """
-        rules = [CombinationRule(), ConcatenationRule()]
-
         # Apply each rule to process the tokens
-        for rule in rules:
+        for rule in self._rules:
             new_tokens = []
             i = 0
 


### PR DESCRIPTION
### Rules re-instantiated on every `convert()` call
**File:** [`text2digits.py:93`](g:\Development\text2digits\text2digits\text2digits.py)

```python
rules = [CombinationRule(), ConcatenationRule()]
```

This creates two new objects per call with no benefit (both are stateless). Move to `__init__`.

**Fix:** Assign `self._rules = [CombinationRule(), ConcatenationRule()]` in `__init__`, use it in `_parse`.