### PR TITLE
Quality magic index numwords

### DIFF
--- a/text2digits/tokens_basic.py
+++ b/text2digits/tokens_basic.py
@@ -1,7 +1,13 @@
 import enum
 import re
+import types
 from decimal import Decimal
-from typing import Optional
+from typing import NamedTuple, Optional
+
+
+class NumEntry(NamedTuple):
+    scale: int
+    value: int
 
 
 class WordType(enum.Enum):
@@ -18,32 +24,34 @@ class WordType(enum.Enum):
 
 class Token(object):
     # Static init code (only executed once and not for each token instance)
-    UNITS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine']
-    TEENS = ['ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen', 'eighteen',
-             'nineteen']
-    TENS = ['twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy', 'eighty', 'ninety']
-    SCALES = ['hundred', 'thousand', 'million', 'billion', 'trillion']
-    SCALE_VALUES = [100, 1_000, 10_000, 1_000_000, 10_000_000, 1_000_000_000, 100_000_000_000, 1_000_000_000_000]  # used for has_large_scale
-    INDIAN_SCALES = ['lakh', 'crore', 'arab', 'kharab']
-    CONJUNCTION = ['and']
-    ORDINAL_WORDS = {'first': 'one', 'second': 'two', 'third': 'three', 'fifth': 'five',
-                     'eighth': 'eight', 'ninth': 'nine', 'twelfth': 'twelve'}
-    ORDINAL_ENDINGS = [('ieth', 'y'), ('th', '')]
+    UNITS = ('zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine')
+    TEENS = ('ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen', 'eighteen',
+             'nineteen')
+    TENS = ('twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy', 'eighty', 'ninety')
+    SCALES = ('hundred', 'thousand', 'million', 'billion', 'trillion')
+    SCALE_VALUES = frozenset({100, 1_000, 10_000, 1_000_000, 10_000_000, 1_000_000_000, 100_000_000_000, 1_000_000_000_000})  # used for has_large_scale
+    INDIAN_SCALES = ('lakh', 'crore', 'arab', 'kharab')
+    CONJUNCTION = frozenset({'and'})
+    ORDINAL_WORDS = types.MappingProxyType({'first': 'one', 'second': 'two', 'third': 'three', 'fifth': 'five',
+                                            'eighth': 'eight', 'ninth': 'nine', 'twelfth': 'twelve'})
+    ORDINAL_ENDINGS = (('ieth', 'y'), ('th', ''))
 
-    numwords = {
-        'and': (1, 0)  # (scale, value)
+    _numwords_build = {
+        'and': NumEntry(scale=1, value=0)
     }
     for idx, word in enumerate(UNITS):
-        numwords[word] = (1, idx)
+        _numwords_build[word] = NumEntry(scale=1, value=idx)
     for idx, word in enumerate(TEENS):
-        numwords[word] = (1, idx + 10)
+        _numwords_build[word] = NumEntry(scale=1, value=idx + 10)
     for idx, word in enumerate(TENS):
-        numwords[word] = (1, (idx + 2) * 10)
+        _numwords_build[word] = NumEntry(scale=1, value=(idx + 2) * 10)
     for idx, word in enumerate(SCALES):
-        numwords[word] = (10 ** (idx * 3 or 2), 0)
+        _numwords_build[word] = NumEntry(scale=10 ** (idx * 3 or 2), value=0)
     for idx, word in enumerate(INDIAN_SCALES):
-        numwords[word] = (10 ** (5 + idx * 2), 0)
-    numwords['oh'] = (1, 0)  # alias for zero; kept separate to avoid index-10 collision in UNITS enumeration
+        _numwords_build[word] = NumEntry(scale=10 ** (5 + idx * 2), value=0)
+    _numwords_build['oh'] = NumEntry(scale=1, value=0)  # alias for zero; kept separate to avoid index-10 collision in UNITS enumeration
+    numwords = types.MappingProxyType(_numwords_build)
+    del _numwords_build
 
     def __init__(self, word: str, glue: str) -> None:
         """
@@ -119,7 +127,7 @@ class Token(object):
             else:
                 return Decimal(self._word)
         elif self.type != WordType.OTHER:
-            return Decimal(Token.numwords[self._word][1])
+            return Decimal(Token.numwords[self._word].value)
         raise ValueError(f"Cannot compute value for token of type {self.type!r} (word={self.word_raw!r})")
 
     def scale(self) -> Decimal:
@@ -132,7 +140,7 @@ class Token(object):
             else:
                 return Decimal(1)
         elif self.type != WordType.OTHER:
-            return Decimal(Token.numwords[self._word][0])
+            return Decimal(Token.numwords[self._word].scale)
         raise ValueError(f"Cannot compute scale for token of type {self.type!r} (word={self.word_raw!r})")
 
     def text(self) -> str:


### PR DESCRIPTION

### `numwords` tuple fields accessed by magic index
**File:** [`tokens_basic.py:117, 129`](g:\Development\text2digits\text2digits\tokens_basic.py)

```python
return Decimal(Token.numwords[self._word][1])  # what is [1]?
return Decimal(Token.numwords[self._word][0])  # what is [0]?
```

`numwords` stores `(scale, value)` tuples accessed by index 0/1. This is opaque and error-prone.

**Fix:** Define a `NamedTuple` (e.g. `NumEntry = NamedTuple('NumEntry', [('scale', int), ('value', int)])`) and use `.scale` / `.value` field names.
