### PR TITLE
Add __all__ to declare public API

### DIFF
--- a/text2digits/__init__.py
+++ b/text2digits/__init__.py
@@ -2,3 +2,4 @@ from text2digits.text2digits import Text2Digits
 
 name = "text2digits"
 __version__ = "0.0.9"
+__all__ = ['Text2Digits']


### PR DESCRIPTION
### No `__all__` defined in `__init__.py`
**File:** [`__init__.py`](g:\Development\text2digits\text2digits\__init__.py)

The public API is not declared. `from text2digits import *` imports everything.

**Fix:** Add `__all__ = ['Text2Digits']`.