### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: pytest / Python ${{ matrix.python-version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: ruff + mypy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+  
 jobs:
   build:
     name: Build distribution


### PR DESCRIPTION
Potential fix for [https://github.com/ShailChoksi/text2digits/security/code-scanning/3](https://github.com/ShailChoksi/text2digits/security/code-scanning/3)

Add an explicit `permissions` block to the workflow (or the specific job) to enforce least privilege for `GITHUB_TOKEN`.  
Best single fix here without changing functionality: define workflow-level permissions with `contents: read`, which is sufficient for `actions/checkout` and does not grant unnecessary write scopes. This applies to all jobs unless overridden, keeps behavior intact, and satisfies CodeQL.

Edit file: `.github/workflows/ci.yml`  
Region: after the `on:` trigger block and before `jobs:` (between current lines 8 and 9).

No imports, methods, or extra definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
